### PR TITLE
fix: login 상태 유지

### DIFF
--- a/src/0_App/index.tsx
+++ b/src/0_App/index.tsx
@@ -3,8 +3,10 @@ import { BrowserRouter } from "react-router-dom";
 import Page from "../1_Page";
 import Nav from "./ui/Nav";
 import Modals from "./ui/Modals";
+import useLoadMyInfo from "./model/useLoadMyInfo";
 
 const App = () => {
+  useLoadMyInfo();
   return (
     <BrowserRouter>
       <main className=" w-full m-auto h-full justify-center items-center bg-light-blue">

--- a/src/0_App/model/useLoadMyInfo.ts
+++ b/src/0_App/model/useLoadMyInfo.ts
@@ -1,0 +1,29 @@
+import React from "react";
+import useGetMyInfo from "../../3_Entity/Account/useGetMyInfo";
+import { useAuthStore } from "../../4_Shared/lib/useMyInfo";
+import { useCookies } from "react-cookie";
+
+const useLoadMyInfo = (): [MyInfo] => {
+  const [myInfo, loading] = useGetMyInfo();
+  const { login } = useAuthStore();
+  const [cookies] = useCookies(["access_token"]);
+
+  React.useEffect(() => {
+    if (!loading && myInfo) {
+      const { player_status, user_idx, profile_image, team_idx } = myInfo;
+      login({
+        playerStatus: player_status,
+        accessToken: cookies.access_token,
+        userIdx: user_idx,
+        communityRoleIdx: 0,
+        teamRoleIdx: 0,
+        teamIdx: team_idx,
+        profileImg: profile_image,
+      });
+    }
+  }, [myInfo, loading, login, cookies.access_token]);
+
+  return [myInfo];
+};
+
+export default useLoadMyInfo;

--- a/src/1_Page/index.tsx
+++ b/src/1_Page/index.tsx
@@ -10,10 +10,7 @@ import Login from "./Login";
 import Championship from "./Championship";
 import { useIsLogin } from "../4_Shared/lib/useMyInfo";
 
-const TEST = import.meta.env.VITE_TEST;
-
 const Page = () => {
-  console.log(TEST);
   const [isLogin] = useIsLogin(); // accessToken 존재 여부 확인
   return (
     <div className="w-full h-full flex justify-center">

--- a/src/3_Entity/Account/types/response.d.ts
+++ b/src/3_Entity/Account/types/response.d.ts
@@ -42,3 +42,24 @@ type SignInData = {
 type DiscordOAuthUrl = {
   url: string;
 };
+
+type MyInfo = {
+  user_idx: number;
+  phone: string;
+  id: string;
+  discord_id: string;
+  nickname: string;
+  profile_image: string | null;
+  platform: string | null;
+  common_status_idx: number;
+  message: string | null;
+  discord_tag: string | null;
+  mmr: number;
+  player_status: string;
+  match_position_idx: number;
+  team_idx: number | null;
+  team_name: string | null;
+  team_short_name: string | null;
+  team_color: string | null;
+  team_emblem: string | null;
+}

--- a/src/3_Entity/Account/useGetMyInfo.ts
+++ b/src/3_Entity/Account/useGetMyInfo.ts
@@ -1,0 +1,28 @@
+import React from "react";
+import { useFetchData } from "../../4_Shared/util/apiUtil.ts";
+
+const useGetMyInfo = (): [MyInfo, boolean] => {
+  const [serverState, request, loading] = useFetchData();
+  const [myInfo, setMyInfo] = React.useState<MyInfo>({} as MyInfo);
+
+  React.useEffect(() => {
+    request("GET", `/account/myinfo/`, null, true);
+  }, [request]);
+
+  React.useEffect(() => {
+    if (!loading && serverState) {
+      switch (serverState.status) {
+        case 200:
+          if ("data" in serverState) {
+            setMyInfo((serverState as { data: MyInfo }).data);
+          }
+          break;
+      }
+      setMyInfo((serverState as { data: MyInfo }).data);
+    }
+  }, [loading, serverState]);
+
+  return [myInfo, loading];
+};
+
+export default useGetMyInfo;

--- a/src/3_Entity/Account/usePostSignIn.ts
+++ b/src/3_Entity/Account/usePostSignIn.ts
@@ -1,19 +1,11 @@
 import React from "react";
-import { useCookies } from "react-cookie";
 import { useFetchData } from "../../4_Shared/util/apiUtil";
+import { useAuthStore } from "../../4_Shared/lib/useMyInfo";
+import { useCookies } from "react-cookie";
 
 const usePostSignIn = (): [(props: PostSignInProps) => void] => {
   const [serverState, request, loading] = useFetchData();
-  const [, setCookie] = useCookies([
-    "player_status",
-    "access_token",
-    "user_idx",
-    "profile_image",
-    "team_idx",
-    "team_role_idx",
-    "community_role_idx",
-  ]);
-
+  const { login } = useAuthStore();
   const postSignIn = (props: PostSignInProps) => {
     const { id, password } = props;
     request(
@@ -26,6 +18,7 @@ const usePostSignIn = (): [(props: PostSignInProps) => void] => {
       false
     );
   };
+  const [, setCookie] = useCookies(["access_token"]);
 
   React.useEffect(() => {
     if (!loading && serverState) {
@@ -39,22 +32,24 @@ const usePostSignIn = (): [(props: PostSignInProps) => void] => {
           team_role_idx,
           community_role_idx,
         } = serverState.data as SignInData;
+        login({
+          playerStatus: player_status,
+          accessToken: access_token,
+          userIdx: user_idx,
+          communityRoleIdx: community_role_idx,
+          teamRoleIdx: team_role_idx,
+          teamIdx: team_idx,
+          profileImg: profile_image,
+        });
         const options = { path: "/", maxAge: 86400 };
-
-        setCookie("player_status", player_status, options);
         setCookie("access_token", access_token, options);
-        setCookie("user_idx", user_idx, options);
-        setCookie("profile_image", profile_image, options);
-        setCookie("team_idx", team_idx, options);
-        setCookie("team_role_idx", team_role_idx, options);
-        setCookie("community_role_idx", community_role_idx, options);
 
         window.history.back();
       } else if (serverState.status === 400 || serverState.status === 404) {
         alert("아이디 또는 비밀번호를 확인해주세요.");
       }
     }
-  }, [loading, serverState, setCookie]);
+  }, [loading, serverState]);
 
   return [postSignIn];
 };

--- a/src/4_Shared/lib/useMyInfo.ts
+++ b/src/4_Shared/lib/useMyInfo.ts
@@ -1,52 +1,94 @@
 import { useCookies } from "react-cookie";
 import { useNavigate } from "react-router-dom";
+import { create } from "zustand";
 
+type AuthState = {
+  playerStatus: string | null;
+  accessToken: string | null;
+  userIdx: number | null;
+  communityRoleIdx: number | null;
+  teamRoleIdx: number | null;
+  teamIdx: number | null;
+  profileImg: string | null;
+  login: (data: {
+    accessToken: string;
+    userIdx: number;
+    communityRoleIdx: number | null;
+    teamRoleIdx: number | null;
+    teamIdx: number | null;
+    playerStatus: string;
+    profileImg: string | null;
+  }) => void;
+  logout: () => void;
+};
+
+export const useAuthStore = create<AuthState>()((set) => ({
+  accessToken: null,
+  userIdx: null,
+  communityRoleIdx: null,
+  teamRoleIdx: null,
+  teamIdx: null,
+  playerStatus: null,
+  profileImg: null,
+  login: (data) => set({ ...data }),
+  logout: () =>
+    set({
+      accessToken: null,
+      userIdx: null,
+      communityRoleIdx: null,
+      teamRoleIdx: null,
+      teamIdx: null,
+      profileImg: null,
+      playerStatus: null,
+    }),
+}));
+
+
+// 로그인 여부 확인
 export const useIsLogin = (): [boolean] => {
   const [cookies] = useCookies(["access_token"]);
-  return [!!cookies.access_token];
+  const accessToken = cookies.access_token;
+  return [!!accessToken];
 };
 
-export const useMyCommunityRoleIdx = (): [number | null] => {
-  const [cookies] = useCookies(["community_role_idx"]);
-  return [cookies.community_role_idx];
-};
-
-export const useMyTeamRoleIdx = (): [number | null] => {
-  const [cookies] = useCookies(["team_role_idx"]);
-  return [cookies.team_role_idx];
-};
-
-export const useMyTeamIdx = (): [number | null] => {
-  const [cookies] = useCookies(["team_idx"]);
-  return [cookies.team_idx];
-};
-
+// 유저 인덱스
 export const useMyUserIdx = (): [number | null] => {
-  const [cookies] = useCookies(["user_idx"]);
-  return [cookies.user_idx];
+  const userIdx = useAuthStore((state) => state.userIdx);
+  return [userIdx];
+};
+
+// 커뮤니티 역할 인덱스
+export const useMyCommunityRoleIdx = (): [number | null] => {
+  const roleIdx = useAuthStore((state) => state.communityRoleIdx);
+  return [roleIdx];
+};
+
+// 팀 역할 인덱스
+export const useMyTeamRoleIdx = (): [number | null] => {
+  const roleIdx = useAuthStore((state) => state.teamRoleIdx);
+  return [roleIdx];
+};
+
+// 팀 인덱스
+export const useMyTeamIdx = (): [number | null] => {
+  const teamIdx = useAuthStore((state) => state.teamIdx);
+  return [teamIdx];
 };
 
 export const useLogout = (): [() => void] => {
+  const logout = useAuthStore((state) => state.logout);
   const navigate = useNavigate();
-  const [, , removeCookie] = useCookies([
-    "access_token",
-    "community_role_idx",
-    "team_role_idx",
-    "team_idx",
-    "user_idx",
-  ]);
+  const [, , removeCookie] = useCookies(["access_token"]);
 
   return [
     () => {
-      removeCookie("access_token");
-      removeCookie("community_role_idx");
-      removeCookie("team_role_idx");
-      removeCookie("team_idx");
-      removeCookie("user_idx");
+      logout();
+      removeCookie("access_token", { path: "/" });
       navigate("/");
     },
   ];
 };
+
 
 export const useRemoveAllCookie = () => {
   const [, , removeCookie] = useCookies([


### PR DESCRIPTION
기존에는 사용자 정보를 쿠키에 직접 저장하는 방식으로 로그인 유지를 처리하고 있었습니다.
하지만 이 방식은 개발 지식이 없는 일반 사용자조차도 브라우저의 개발자 도구를 통해 
쿠키를 쉽게 확인하고 조작할 수 있다는 보안적인 문제가 있었습니다.

이에 따라, 사용자 정보를 쿠키에서 제거하고 accessToken만 저장하도록 구조를 변경했습니다.
사용자 정보는 accessToken 유효성 검사를 통해 서버에서 받아오고, 
클라이언트 전역 상태로 관리되며, 새로고침 시에도 accessToken이 존재하면 정보를 다시 불러옵니다.

이로써 보안성과 구조의 명확성이 개선되었습니다.
