### PR TITLE
fix : 비로그인 상태 프로필 조회 불가 로직 수정

### DIFF
--- a/src/4_Shared/util/apiUtil.ts
+++ b/src/4_Shared/util/apiUtil.ts
@@ -102,11 +102,10 @@ export const useFetchData = (): [
           );
 
           const newAccessToken = refreshResponse.data.access_token;
-          console.log(newAccessToken)
+          console.log(newAccessToken);
           setCookie("access_token", newAccessToken); // access_token을 쿠키에 저장
 
-          axiosInstance.defaults.headers["Authorization"] =
-            newAccessToken;
+          axiosInstance.defaults.headers["Authorization"] = newAccessToken;
           processQueue(newAccessToken);
           return axiosInstance(originalRequest);
         } catch (refreshError) {
@@ -137,11 +136,12 @@ export const useFetchData = (): [
           method: method,
           url: `${SERVER_URL}${endpoint}`,
           params: {},
-          headers: authorization
-            ? {
-                Authorization: `${cookies.access_token}`,
-              }
-            : undefined,
+          headers:
+            authorization && cookies.access_token
+              ? {
+                  Authorization: `${cookies.access_token}`,
+                }
+              : undefined,
           data: body ?? undefined,
         });
 
@@ -151,12 +151,11 @@ export const useFetchData = (): [
           const { status, data } = error.response ?? {};
           console.log("endpoint", endpoint);
           console.log("body", body);
+          console.log("authorization", authorization);
+          console.log(`auth ${cookies.access_token}`);
           console.log("status", status);
           console.log("message", data.message);
           setServerState({ status });
-          console.log("endpoint", endpoint);
-          console.log("body", body);
-          console.log("서버 오류:", status, data);
 
           if (status === 500) {
             console.error("Internal Server Error:", status, data.message);


### PR DESCRIPTION
비로그인 상태 프로필 조회 불가 이슈 확인 

프로필 페이지는 토큰과 조회된 userIdx를 비교해서 
자신의 페이지인지 아닌지 판단을합니다. (isMine 값 이용)
따라서 항상 해더에 토큰을 담아서 보내는데 토큰이 없는 상태에서 
토큰을 담으려고 시도한다면   Authorization: "undefined" 를 담아서 보내는 문제 발생 확인

해더 자체를 비우면 문제가 해결되었음 

수정 전 문제

src/4_Shared/util/apiUtil
- useFetchData()

authorization이 true인데 토큰이 없으면 문자열 undefined가 해더에 담겨서 
서버에서 처리가 안되었음 

```javascript
  headers: authorization 
            ? {
                Authorization: `${cookies.access_token}`,
              }
            : undefined,
```
- 토큰이 없을 경우 cookies.access_token은 undefined.
- 위 코드로 인해 Authorization: "undefined"가 string 타입으로 요청 헤더에 포함됨.
- 서버는 "undefined" 문자열을 JWT로 해석하려다 jwt malformed 에러 발생.

액세스 토큰이 있을때만 해더에 담아서 보내도록 수정 

수정 후 코드
```javascript
headers:
  authorization && cookies.access_token
    ? { Authorization: `${cookies.access_token}` }
    : undefined,
```

비로그인 상태 프로필 조회 버그 수정했습니다 