### PR TITLE
fix - championship edit page QA 사항 수정했습니다.  [stack 1]

### DIFF
--- a/src/1_Page/ChampionshipEdit/index.tsx
+++ b/src/1_Page/ChampionshipEdit/index.tsx
@@ -227,10 +227,7 @@ const ChampionshipForm = () => {
               <div className="pt-6 flex justify-between">
                 <button
                   type="button"
-                  // onClick={() => setActiveTab(CHAMPIONSHIP_EDIT_TAB.AWARDS)}
-                  onClick={() => {
-                    console.log(errors);
-                  }}
+                  onClick={() => setActiveTab(CHAMPIONSHIP_EDIT_TAB.AWARDS)}
                   className="px-6 py-2.5 border border-gray-300 text-gray-700 font-medium rounded-lg hover:bg-gray-50 transition">
                   이전: 수상 항목
                 </button>

--- a/src/1_Page/ChampionshipEdit/index.tsx
+++ b/src/1_Page/ChampionshipEdit/index.tsx
@@ -49,7 +49,7 @@ const ChampionshipForm = () => {
     handleSubmit,
     control,
     watch,
-    formState: { isSubmitting, errors },
+    formState: { isSubmitting },
     reset,
   } = method;
 

--- a/src/1_Page/ChampionshipEdit/lib/schema.ts
+++ b/src/1_Page/ChampionshipEdit/lib/schema.ts
@@ -5,7 +5,6 @@ export const schema = Yup.object().shape({
   championship_type_idx: Yup.number().required("대회 종류는 필수값입니다."),
   championship_list_name: Yup.string()
     .max(30, "대회 이름은 최대 30글자까지 가능합니다.")
-    .matches(/^[가-힣A-Za-z\s]+$/, "대회 이름은 한글과 영어만 입력 가능합니다.")
     .required("대회 이름을 입력해주세요."),
   championship_list_description: Yup.string()
     .max(500, "대회 설명은 최대 500글자까지 입력 가능합니다.")

--- a/src/1_Page/ChampionshipEdit/model/useManageServerState.ts
+++ b/src/1_Page/ChampionshipEdit/model/useManageServerState.ts
@@ -5,27 +5,29 @@ const useManageServerState = (
   serverState: Record<string, unknown> | null,
   isEditMode: boolean
 ) => {
-  const sucessMessage = isEditMode
+  const successMessage = isEditMode
     ? "수정에 성공했습니다"
     : "생성에 성공했습니다";
   const navigate = useNavigate();
-  const naviateUrl = "/championship";
 
   const [searchParams] = useSearchParams();
   const championshipIdx = Number(searchParams.get("championshipIdx") ?? 0);
-  const editUrl = `/championship/${championshipIdx}`;
 
   React.useEffect(() => {
     if (!serverState) return;
     switch (serverState.status) {
       case 200: {
-        alert(sucessMessage);
+        alert(successMessage);
+        const championshipListIdx = (
+          serverState.data as {
+            championship_list_idx: number;
+          }
+        ).championship_list_idx;
+
         const targetUrl = isEditMode
-          ? editUrl
-          : `${naviateUrl}/${
-              (serverState.data as { championship_list_idx: number })
-                .championship_list_idx
-            }`;
+          ? `/championship/${championshipIdx}`
+          : `/championship/${championshipListIdx}`;
+
         navigate(targetUrl);
         break;
       }

--- a/src/1_Page/ChampionshipEdit/model/useManageServerState.ts
+++ b/src/1_Page/ChampionshipEdit/model/useManageServerState.ts
@@ -18,8 +18,9 @@ const useManageServerState = (
     switch (serverState.status) {
       case 200: {
         alert(successMessage);
+        console.log(serverState);
         const championshipListIdx = (
-          serverState.data as {
+          serverState as {
             championship_list_idx: number;
           }
         ).championship_list_idx;

--- a/src/1_Page/ChampionshipEdit/ui/AwardTab/index.tsx
+++ b/src/1_Page/ChampionshipEdit/ui/AwardTab/index.tsx
@@ -35,6 +35,12 @@ const AwardTab = (props: AwartTabProps) => {
         )}
       </div>
 
+      {errors.championship_award && (
+        <p className="text-red-500 text-sm mt-1">
+          {errors.championship_award.message}
+        </p>
+      )}
+
       {errors.championship_award?.root?.message && (
         <p className="text-red-500 text-sm mt-1">
           {errors.championship_award.root.message}

--- a/src/1_Page/ChampionshipEdit/ui/DateTab/index.tsx
+++ b/src/1_Page/ChampionshipEdit/ui/DateTab/index.tsx
@@ -8,6 +8,7 @@ const DateTab = () => {
     watch,
     control,
   } = useFormContext();
+
   const { fields } = useFieldArray({
     control,
     name: "championship_award",

--- a/src/1_Page/ChampionshipEdit/ui/TeamTab/index.tsx
+++ b/src/1_Page/ChampionshipEdit/ui/TeamTab/index.tsx
@@ -42,7 +42,7 @@ const TeamTab = () => {
       {championshipType && (
         <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
           <p className="text-sm text-amber-800">
-            {championshipType === 0
+            {championshipType == 0
               ? "리그는 팀 선택 제한이 없습니다"
               : `${championshipTypes[championshipType]}은 정확히 ${matchCount[championshipType]}개의 팀을 선택해야 합니다.`}
           </p>

--- a/src/1_Page/ChampionshipEdit/util/convert.ts
+++ b/src/1_Page/ChampionshipEdit/util/convert.ts
@@ -37,19 +37,13 @@ export const convertToAPIChampionship = (
   formData.append("championship_list_start_date", championship_list_start_date);
   formData.append("championship_list_end_date", championship_list_end_date);
 
-  // 배열 형태의 데이터는 보통 JSON 문자열로 변환해서 전달합니다.
-  // 대신 각각의 요소를 별도로 append합니다.
   participation_team_idxs.forEach((idx) => {
     formData.append("participation_team_idxs", String(idx));
   });
 
-  // 각 award의 이름 배열을 별도로 append합니다.
   championship_award.forEach((award) => {
     formData.append("championship_award_name", award.championship_award_name);
   });
-
-  // 만약 나머지(rest) 데이터가 있을 경우에도 원하는대로 추가할 수 있습니다.
-  // 예: Object.entries(rest).forEach(([key, value]) => formData.append(key, String(value)));
 
   return formData;
 };


### PR DESCRIPTION
1. dateTab의 뒤로가기 버튼이 눌러지지 않던 버그를 수정했습니다.

2. 개인 수상항목 미입력시 입력 하는 애러 태그 미출력 버그 수정

3. 생성후 navigate 수정 

4. 대회명 스키마 수정했습니다
- 기존 : 한글 , 영어 30글자만 허용
- 이후 : 30글자 이내로 모두 허용