### PR TITLE
fix -  team page 

### DIFF
--- a/src/3_Entity/Team/useGetSignMemberList.ts
+++ b/src/3_Entity/Team/useGetSignMemberList.ts
@@ -12,7 +12,7 @@ const useGetSignMemberList = (
   React.useEffect(() => {
     const endPoint = `/team/${teamListIdx}/application/list`;
     request("GET", endPoint, null, true);
-  }, []);
+  }, [teamListIdx]);
 
   React.useEffect(() => {
     if (!loading && serverState && "access_list" in serverState) {

--- a/src/3_Entity/Team/useGetTeamAwards.ts
+++ b/src/3_Entity/Team/useGetTeamAwards.ts
@@ -8,7 +8,7 @@ const useGetTeamAwards = (teamListIdx: number): [TeamAwards[], boolean] => {
   React.useEffect(() => {
     const endPoint = `/team/${teamListIdx}/award`;
     request("GET", endPoint, null, true);
-  }, []);
+  }, [teamListIdx]);
 
   React.useEffect(() => {
     if (!loading && serverState && "team_award" in serverState) {

--- a/src/3_Entity/Team/useGetTeamHistory.ts
+++ b/src/3_Entity/Team/useGetTeamHistory.ts
@@ -8,7 +8,7 @@ const useGetTeamHistory = (teamListIdx: number): [TeamHistory[], boolean] => {
   React.useEffect(() => {
     const endPoint = `/team/${teamListIdx}/history`;
     request("GET", endPoint, null, true);
-  }, []);
+  }, [teamListIdx]);
 
   React.useEffect(() => {
     if (!loading && serverState && "team_history" in serverState) {

--- a/src/3_Entity/Team/useGetTeamInfo.ts
+++ b/src/3_Entity/Team/useGetTeamInfo.ts
@@ -10,7 +10,7 @@ const useGetTeamInfo = (teamListIdx: number): [TeamInfo, boolean] => {
   React.useEffect(() => {
     const endPoint = `/team/${teamListIdx}/information`;
     request("GET", endPoint, null, true);
-  }, []);
+  }, [teamListIdx]);
 
   React.useEffect(() => {
     if (!loading && serverState && "team" in serverState) {

--- a/src/3_Entity/Team/useGetTeamInfo.ts
+++ b/src/3_Entity/Team/useGetTeamInfo.ts
@@ -1,10 +1,12 @@
 import React from "react";
 import { useFetchData } from "../../4_Shared/util/apiUtil";
+import { useNavigate } from "react-router-dom";
 
 const useGetTeamInfo = (teamListIdx: number): [TeamInfo, boolean] => {
   const [serverState, request, loading] = useFetchData();
   const [teamInfo, setTeamInfo] = React.useState<TeamInfo>({} as TeamInfo);
 
+  const navigate = useNavigate();
   React.useEffect(() => {
     const endPoint = `/team/${teamListIdx}/information`;
     request("GET", endPoint, null, true);
@@ -15,6 +17,23 @@ const useGetTeamInfo = (teamListIdx: number): [TeamInfo, boolean] => {
       setTeamInfo((serverState as { team: TeamInfo }).team);
     }
   }, [loading, serverState]);
+
+  React.useEffect(() => {
+    if (!serverState) return;
+
+    switch (serverState.status) {
+      case 200:
+        return;
+      case 404:
+        alert("존재하지 않는 팀입니다.");
+        navigate(-1);
+        return;
+      default:
+        alert("서버 오류입니다.");
+        navigate(-1);
+        return;
+    }
+  }, [serverState]);
 
   return [teamInfo, loading];
 };

--- a/src/3_Entity/Team/useGetTeamMembers.ts
+++ b/src/3_Entity/Team/useGetTeamMembers.ts
@@ -14,7 +14,7 @@ const useGetTeamMembers = (
   React.useEffect(() => {
     const endPoint = `/team/${teamIdx}/member?page=${page}`;
     request("GET", endPoint, null, true);
-  }, [page]);
+  }, [teamIdx, page]);
 
   React.useEffect(() => {
     if (!loading && serverState && "member" in serverState) {


### PR DESCRIPTION
팀이 없는 경우 페이지 리다이렉션 처리  
teamListIdx param 변경 시 API 동기화를 위한 의존성 추가

- 팀이 존재하지 않는 경우 navigate를 통해 다른 페이지로 이동 처리
- teamListIdx param이 변경되더라도 컴포넌트가 유지되므로,
  관련 API 호출이 정상적으로 이루어지도록 useEffect의 의존성 배열에 teamListIdx 추가