### PR TITLE
fix: get user info api

### DIFF
--- a/src/3_Entity/Account/useGetUserInfo.ts
+++ b/src/3_Entity/Account/useGetUserInfo.ts
@@ -9,7 +9,7 @@ const useGetUserInfo = (userIdx: number): [UserInfo, boolean] => {
 
   React.useEffect(() => {
     const endPoint = `/account/info/${userIdx}`;
-    request("GET", endPoint, null, true);
+    request("GET", endPoint, null, false);
   }, []);
 
   React.useEffect(() => {


### PR DESCRIPTION
get user info api에서 jwt expired 500 status error
가 발생하던 문제를 수정했습니다.
token인증이 필요없는 경우, token을 보내 발생한 문제였습니다.