### PR TITLE
fix : repeat 관련 엔티티

### DIFF
--- a/src/3_Entity/Team/useGetRepeatShortTeam.ts
+++ b/src/3_Entity/Team/useGetRepeatShortTeam.ts
@@ -1,38 +1,16 @@
-import React from "react";
 import { useFetchData } from "../../4_Shared/util/apiUtil";
 
 const useGetRepeatShortTeam = (): [
-  boolean,
-  boolean,
-  (teamShortName: string) => void
+  (teamShortName: string) => Promise<number | undefined>
 ] => {
-  const [serverState, request, loading] = useFetchData();
-  const [isRepeat, setIsRepeat] = React.useState<boolean>(false);
+  const [, request] = useFetchData();
 
-  const getRepeatShortTeam = (teamShortName: string) => {
+  const getRepeatShortTeam = async (teamShortName: string) => {
     const endPoint = `/team/check_short_name/${teamShortName}`;
-    request("GET", endPoint, null, true);
+    return await request("GET", endPoint, null, true);
   };
 
-  React.useEffect(() => {
-    if (!serverState) return;
-
-    switch (serverState.status) {
-      case 200:
-        setIsRepeat(false);
-        console.log("중복 없음");
-        return;
-      case 409:
-        setIsRepeat(true);
-        console.log("중복");
-        return;
-      default:
-        setIsRepeat(true);
-        return;
-    }
-  }, [serverState]);
-
-  return [isRepeat, loading, getRepeatShortTeam];
+  return [getRepeatShortTeam];
 };
 
 export default useGetRepeatShortTeam;

--- a/src/3_Entity/Team/useGetRepeatTeam.ts
+++ b/src/3_Entity/Team/useGetRepeatTeam.ts
@@ -1,34 +1,16 @@
-import React from "react";
 import { useFetchData } from "../../4_Shared/util/apiUtil";
 
-const useGetRepeatTeam = (): [boolean, boolean, (teamName: string) => void] => {
-  const [serverState, request, loading] = useFetchData();
-  const [isRepeat, setIsRepeat] = React.useState<boolean>(false);
+const useGetRepeatTeam = (): [
+  (teamName: string) => Promise<number | undefined>
+] => {
+  const [, request] = useFetchData();
 
-  const getRepeatTeam = (teamName: string) => {
+  const getRepeatTeam = async (teamName: string) => {
     const endPoint = `/team/check_name/${teamName}`;
-    request("GET", endPoint, null, true);
+    return request("GET", endPoint, null, true);
   };
 
-  React.useEffect(() => {
-    if (!serverState) return;
-
-    switch (serverState.status) {
-      case 200:
-        setIsRepeat(false);
-        console.log("중복 없음");
-        return;
-      case 409:
-        setIsRepeat(true);
-        console.log("중복");
-        return;
-      default:
-        setIsRepeat(true);
-        return;
-    }
-  }, [serverState]);
-
-  return [isRepeat, loading, getRepeatTeam];
+  return [getRepeatTeam];
 };
 
 export default useGetRepeatTeam;

--- a/src/3_Entity/Team/usePostMakeTeam.ts
+++ b/src/3_Entity/Team/usePostMakeTeam.ts
@@ -1,15 +1,42 @@
+import React from "react";
 import { useFetchData } from "../../4_Shared/util/apiUtil";
+import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "../../4_Shared/lib/useMyInfo";
 const usePostMakeTeam = (): [
-  postMakeTeam: (props: UsePostMakeTeam) => void,
+  postMakeTeam: (props: UsePostMakeTeam) => Promise<number | undefined>,
   serverState: Record<string, unknown> | null,
   loading: boolean
 ] => {
   const [serverState, request, loading] = useFetchData();
+  const navigate = useNavigate();
+  const { setTeamIdx } = useAuthStore();
 
-  const postMakeTeam = (props: UsePostMakeTeam) => {
+  const postMakeTeam = async (props: UsePostMakeTeam) => {
     const endPoint = `/team`;
-    request("POST", endPoint, props, true);
+    return await request("POST", endPoint, props, true);
   };
+
+  React.useEffect(() => {
+    if (!serverState) return;
+    switch (serverState.status) {
+      case 200:
+        alert("팀 생성 성공");
+        navigate(`/team/${serverState.team_list_idx}`);
+        setTeamIdx(serverState.team_list_idx as number);
+        break;
+      case 403:
+        alert("이미 팀이 존재합니다");
+        break;
+      case 409:
+        alert("팀명 증복입니다");
+        alert("팀 약칭 증복입니다");
+        console.error("팀 생성 실패", serverState.data);
+        break;
+      default:
+        alert("서버 오류입니다.");
+        break;
+    }
+  }, [serverState]);
 
   return [postMakeTeam, serverState, loading];
 };


### PR DESCRIPTION
useEffect 대신 request 활용하도록 수정했습니다

team 페이지와 team-list 페이지에서 공통으로 사용해서 브랜치를 분리해서 작업했습니다 