### PR TITLE
fix - 게시물 수정 생성시 다른 게시판에 연동되던 버그 수정했습니다 

### DIFF
--- a/src/1_Page/PostEdit/constant/constant.ts
+++ b/src/1_Page/PostEdit/constant/constant.ts
@@ -1,6 +1,6 @@
-export const CATEGORY_STRING = ["자유", "팀", "커뮤니티"];
+export const CATEGORY_STRING = ["자유", "커뮤니티", "팀"];
 export const CATEGORY_MAP: Record<string, number> = {
   free: 0,
-  team: 1,
-  community: 2,
+  community: 1,
+  team: 2,
 };

--- a/src/3_Entity/Board/usePostBoard.ts
+++ b/src/3_Entity/Board/usePostBoard.ts
@@ -24,12 +24,8 @@ const usePostBoard = (): [
         navigate(`/post/${board_list_idx}`);
         break;
       }
-      case 403: {
-        alert("게시글 작성 권한이 없습니다.");
-        break;
-      }
       default: {
-        alert("게시글을 작성하는 데 실패했습니다.");
+        alert(serverState.message || "게시글 작성에 실패했습니다.");
         break;
       }
     }

--- a/src/3_Entity/Board/usePutBoard.ts
+++ b/src/3_Entity/Board/usePutBoard.ts
@@ -20,12 +20,9 @@ const usePutBoard = (
         navigate(`/post/${boardListIdx}`);
         break;
       }
-      case 403: {
-        alert("게시글 수정 권한이 없습니다.");
-        break;
-      }
+
       default: {
-        alert("게시글을 수정하는데 실패했습니다.");
+        alert(serverState.message || "게시글 작성에 실패했습니다.");
         break;
       }
     }


### PR DESCRIPTION
## 📢 설명
DB 테이블상 기존 해당 아래 순서였으나 
백엔드에서의 변경으로 다른 페이지로 생성이 됨을 확인했습니다 
해당 사항에 대해서 순서 재배치 했습니다 
serverstate Message를 통해 같은 status로 다른 message가 나올때 사용자가 확인가능하도록 수정했습니다 

```
export const CATEGORY_MAP: Record<string, number> = {
  free: 0,
  team: 1,
  community: 2,
};


```

## ✅ 체크 리스트
- [ ] post , put 이후 올바르게 페이지 이동이 되는지 확인부탁드립니다!
- [ ] 오류가 나온다면 message가 올바르게 츨략되는지 확인부탁드립니다!
